### PR TITLE
Add JobBackOff

### DIFF
--- a/job.go
+++ b/job.go
@@ -1,0 +1,38 @@
+package backoff
+
+import (
+	"time"
+)
+
+var (
+	_ BackOff = (*JobBackOff)(nil)
+)
+
+const (
+	DefaultMinJobInterval = 30 * time.Second
+)
+
+// JobBackOff is an exponential backoff implementation for long running jobs.
+// In long running jobs, an operation() that fails after a long Duration should not increments the backoff period.
+// If operation() takes more than MinJobInterval, Reset() is called in NextBackOff().
+type JobBackOff struct {
+	*ExponentialBackOff
+	MinJobInterval time.Duration
+}
+
+// NewJobBackOff creates an instance of JobBackOff using default values.
+func NewJobBackOff(backOff *ExponentialBackOff) *JobBackOff {
+	backOff.MaxElapsedTime = 0
+	return &JobBackOff{
+		ExponentialBackOff: backOff,
+		MinJobInterval:     DefaultMinJobInterval,
+	}
+}
+
+// NextBackOff calculates the next backoff interval.
+func (b *JobBackOff) NextBackOff() time.Duration {
+	if b.GetElapsedTime() >= b.MinJobInterval {
+		b.Reset()
+	}
+	return b.ExponentialBackOff.NextBackOff()
+}

--- a/job_test.go
+++ b/job_test.go
@@ -1,0 +1,43 @@
+package backoff
+
+import (
+	"testing"
+	"time"
+)
+
+func TestJobBackOff(t *testing.T) {
+	var (
+		testInitialInterval     = 500 * time.Millisecond
+		testRandomizationFactor = 0.1
+		testMultiplier          = 2.0
+		testMaxInterval         = 5 * time.Second
+		testMinJobInterval      = 1 * time.Second
+	)
+
+	exp := NewJobBackOff(NewExponentialBackOff())
+	exp.InitialInterval = testInitialInterval
+	exp.RandomizationFactor = testRandomizationFactor
+	exp.Multiplier = testMultiplier
+	exp.MaxInterval = testMaxInterval
+	exp.MinJobInterval = testMinJobInterval
+	exp.Reset()
+
+	var expectedResults = []time.Duration{500, 500, 500, 1000, 2000, 4000, 5000, 5000, 500, 1000, 2000, 4000, 5000, 5000}
+	for i, d := range expectedResults {
+		expectedResults[i] = d * time.Millisecond
+	}
+
+	for i, expected := range expectedResults {
+		// Assert that the next backoff falls in the expected range.
+		var minInterval = expected - time.Duration(testRandomizationFactor*float64(expected))
+		var maxInterval = expected + time.Duration(testRandomizationFactor*float64(expected))
+		if i < 3 || i == 8 {
+			time.Sleep(2 * time.Second)
+		}
+		var actualInterval = exp.NextBackOff()
+		if !(minInterval <= actualInterval && actualInterval <= maxInterval) {
+			t.Error("error")
+		}
+		// assertEquals(t, expected, exp.currentInterval)
+	}
+}


### PR DESCRIPTION
Hi!

We are using your lib in [Traefik](https://github.com/containous/traefik) for long running jobs and we ended in issues like https://github.com/containous/traefik/issues/626.

This PR adds JobBackOff:
>JobBackOff is an exponential backoff implementation for long running jobs.
>In long running jobs, an operation() that fails after a long Duration should not increments the backoff period.
>If operation() takes more than MinJobInterval, Reset() is called in NextBackOff().

Signed-off-by: Emile Vauge <emile@vauge.com>