### PR TITLE
This'll enable exiting out of retries quickly on context cancellation

### DIFF
--- a/retry_with_context.go
+++ b/retry_with_context.go
@@ -1,0 +1,42 @@
+// +build go1.7
+
+package backoff
+
+import (
+	"context"
+	"time"
+)
+
+// RetryNotifyWithContext calls notify function with the error and
+// wait duration for each failed attempt before sleep. It will return
+// early from a sleep when ctx's Done channel is closed, and it will
+// also not call the operation if the context is already canceled.
+func RetryNotifyWithContext(ctx context.Context, operation Operation, b BackOff, notify Notify) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	var err error
+	var next time.Duration
+
+	b.Reset()
+	for {
+		if err = operation(); err == nil {
+			return nil
+		}
+
+		if next = b.NextBackOff(); next == Stop {
+			return err
+		}
+
+		if notify != nil {
+			notify(err, next)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(next):
+		}
+	}
+}

--- a/retry_with_context_test.go
+++ b/retry_with_context_test.go
@@ -1,0 +1,45 @@
+// +build go1.7
+
+package backoff
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRetryWithCanceledContext(t *testing.T) {
+	f := func() error {
+		t.Error("This function shouldn't be called at all")
+		return errors.New("error")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := RetryNotifyWithContext(ctx, f, NewExponentialBackOff(), nil)
+	if err != ctx.Err() {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRetryWithCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	called := false
+	f := func() error {
+		if called {
+			t.Error("This function shouldn't be called more than once")
+		} else {
+			cancel()
+			called = true
+		}
+		return errors.New("error")
+	}
+
+	err := RetryNotifyWithContext(ctx, f, NewExponentialBackOff(), nil)
+	if err != ctx.Err() {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
This is an improved version of #24, with optional `context` support when Go 1.7+ is used. `context` package is now [part of the Go standard library](https://golang.org/doc/go1.7#context) so no extra dependencies required.

p.s. Also using `nil` for context parameter is a bad idea so it is not supported here.
p.p.s. I have not tested it on Go < 1.7 - trusting Travis to do this.